### PR TITLE
feat: update schema to include information about new site endpoints

### DIFF
--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -897,6 +897,20 @@ paths:
               schema:
                 type: string
                 example: "database error"
+  /api/old-sites:
+    get:
+      summary: Get all sites
+      description: Returns a list of all available sites with their location and status information
+      operationId: getSitesOld
+      responses:
+        '200':
+          description: List of sites
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Site'
   /api/sites:
     get:
       summary: Get all sites
@@ -911,30 +925,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Site'
-  /api/public-sites:
-    get:
-      summary: Get sites list
-      description: Returns a list of public sites
-      responses:
-        '200':
-          description: List of public sites
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  sites:
-                    type: array
-                    description: List of sites
-                    items:
-                      $ref: '#/components/schemas/Site'
-        '500':
-          description: Server error
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: "Internal server error"
   /secure/get_groups:
     post:
       summary: Get distinct group identifiers

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -1258,7 +1258,7 @@ paths:
               schema:
                 type: string
                 example: "database error"
-  /api/secure-site:
+  /secure/edit-sites:
     put:
       summary: Update an existing site
       description: Updates an existing site with the provided information

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -911,6 +911,30 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Site'
+  /api/public-sites:
+    get:
+      summary: Get sites list
+      description: Returns a list of public sites
+      responses:
+        '200':
+          description: List of public sites
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sites:
+                    type: array
+                    description: List of sites
+                    items:
+                      $ref: '#/components/schemas/Site'
+        '500':
+          description: Server error
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Internal server error"
   /secure/get_groups:
     post:
       summary: Get distinct group identifiers
@@ -1253,6 +1277,127 @@ paths:
                 description: Error message from cryptographic operation
         '503':
           description: Database operation error
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "database error"
+  /api/secure-site:
+    put:
+      summary: Update an existing site
+      description: Updates an existing site with the provided information
+      security:
+        - sessionAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Site'
+      responses:
+        '200':
+          description: Site successfully updated
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "updated"
+        '400':
+          description: Bad request - invalid site data
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "bad request"
+        '401':
+          description: Unauthorized - User not logged in
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Unauthorized, please login"
+        '500':
+          description: Server error while updating site
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "database error"
+    post:
+      summary: Add a new site
+      description: Creates a new site with the provided information
+      security:
+        - sessionAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Site'
+      responses:
+        '201':
+          description: Site successfully created
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "created"
+        '400':
+          description: Bad request - invalid site data
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "bad request"
+        '401':
+          description: Unauthorized - User not logged in
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Unauthorized, please login"
+        '500':
+          description: Server error while creating site
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "database error"
+    delete:
+      summary: Delete a site
+      description: Removes an existing site from the system
+      security:
+        - sessionAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Site'
+      responses:
+        '200':
+          description: Site successfully deleted
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "deleted"
+        '400':
+          description: Bad request - invalid site data
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "bad request"
+        '401':
+          description: Unauthorized - User not logged in
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Unauthorized, please login"
+        '500':
+          description: Server error while deleting site
           content:
             text/plain:
               schema:

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -897,20 +897,6 @@ paths:
               schema:
                 type: string
                 example: "database error"
-  /api/old-sites:
-    get:
-      summary: Get all sites
-      description: Returns a list of all available sites with their location and status information
-      operationId: getSitesOld
-      responses:
-        '200':
-          description: List of sites
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Site'
   /api/sites:
     get:
       summary: Get all sites


### PR DESCRIPTION
This should have the most up-to-date model that works with the new UI for the ccn-coverage-sites repo