### PR TITLE
feat: create "identity" field for Site

### DIFF
--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -278,7 +278,7 @@ components:
           type: string
           description: Physical address of the site
           example: "5740 Martin Luther King Jr Way S, Seattle, WA 98118"
-        cell_id:
+        cell_ids:
           type: array
           description: Array of cell identifiers associated with the site
           items:
@@ -331,7 +331,7 @@ components:
           type: string
           description: Physical address of the site
           example: "5740 Martin Luther King Jr Way S, Seattle, WA 98118"
-        cell_id:
+        cell_ids:
           type: array
           description: Array of cell identifiers associated with the site
           items:

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -298,6 +298,59 @@ components:
             items:
               type: number
               format: double
+    NewSiteRequest:
+      type: object
+      required:
+        - name
+        - latitude
+        - longitude
+        - status
+        - address
+        - cell_id
+      properties:
+        name:
+          type: string
+          description: Name of the site
+          example: "Filipino Community Center"
+        latitude:
+          type: number
+          format: double
+          description: Geographic latitude coordinate
+          example: 47.681932654395915
+        longitude:
+          type: number
+          format: double
+          description: Geographic longitude coordinate
+          example: -122.31829217664796
+        status:
+          type: string
+          description: Current status of the site
+          enum: [active, confirmed, in-conversation]
+          example: "active"
+        address:
+          type: string
+          description: Physical address of the site
+          example: "5740 Martin Luther King Jr Way S, Seattle, WA 98118"
+        cell_id:
+          type: array
+          description: Array of cell identifiers associated with the site
+          items:
+            type: string
+            example: "cell-123"
+        color:
+          type: string
+          description: Optional color identifier for the site in hex code 
+          example: "#FF5733"
+        boundary:
+          type: array
+          description: Optional geographical boundary coordinates defining the site perimeter as [latitude, longitude] pairs
+          items:
+            type: array
+            minItems: 2
+            maxItems: 2
+            items:
+              type: number
+              format: double
     SitesSummary:
       type: object
       additionalProperties:
@@ -1314,7 +1367,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Site'
+              $ref: '#/components/schemas/NewSiteRequest'
       responses:
         '201':
           description: Site successfully created
@@ -1346,7 +1399,7 @@ paths:
                 example: "database error"
     delete:
       summary: Delete a site
-      description: Removes an existing site from the system
+      description: Removes an existing site from the system using its unique identity
       security:
         - sessionAuth: []
       requestBody:
@@ -1354,7 +1407,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Site'
+              type: object
+              required:
+                - identity
+              properties:
+                identity:
+                  type: string
+                  description: The unique identifier of the site to delete
+                  example: "9a8b7c6d5e4f3g2h1i"
       responses:
         '200':
           description: Site successfully deleted

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -243,6 +243,7 @@ components:
     Site:
       type: object
       required:
+        - identity
         - name
         - latitude
         - longitude
@@ -250,6 +251,10 @@ components:
         - address
         - cell_id
       properties:
+        identity:
+            type: string
+            description: Unique identifier of the user to update
+            example: "9a8b7c6d5e4f3g2h1i"
         name:
           type: string
           description: Name of the site

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -341,7 +341,7 @@ components:
           type: string
           description: Optional color identifier for the site in hex code 
           example: "#FF5733"
-        boundary_array:
+        boundaries:
           type: array
           description: Optional geographical boundary coordinates defining the site perimeter as [latitude, longitude] pairs
           items:

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -897,6 +897,20 @@ paths:
               schema:
                 type: string
                 example: "database error"
+  /api/old-sites:
+    get:
+      summary: Get all sites
+      description: Returns a list of all available sites with their location and status information
+      operationId: getSitesOld
+      responses:
+        '200':
+          description: List of sites
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Site'
   /api/sites:
     get:
       summary: Get all sites
@@ -911,30 +925,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Site'
-  /api/public-sites:
-    get:
-      summary: Get sites list
-      description: Returns a list of public sites
-      responses:
-        '200':
-          description: List of public sites
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  sites:
-                    type: array
-                    description: List of sites
-                    items:
-                      $ref: '#/components/schemas/Site'
-        '500':
-          description: Server error
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: "Internal server error"
   /secure/get_groups:
     post:
       summary: Get distinct group identifiers

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -1258,7 +1258,7 @@ paths:
               schema:
                 type: string
                 example: "database error"
-  /api/secure-site:
+  /secure/edit-sites:
     put:
       summary: Update an existing site
       description: Updates an existing site with the provided information

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -253,8 +253,8 @@ components:
       properties:
         identity:
             type: string
-            description: Unique identifier of the user to update
-            example: "9a8b7c6d5e4f3g2h1i"
+            description: Unique identifier of the site
+            example: "123e4567-e89b-12d3-a456-426614174000"
         name:
           type: string
           description: Name of the site
@@ -288,7 +288,7 @@ components:
           type: string
           description: Optional color identifier for the site in hex code 
           example: "#FF5733"
-        boundary_array:
+        boundaries:
           type: array
           description: Optional geographical boundary coordinates defining the site perimeter as [latitude, longitude] pairs
           items:
@@ -1414,7 +1414,7 @@ paths:
                 identity:
                   type: string
                   description: The unique identifier of the site to delete
-                  example: "9a8b7c6d5e4f3g2h1i"
+                  example: "123e4567-e89b-12d3-a456-426614174000"
       responses:
         '200':
           description: Site successfully deleted

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -911,6 +911,30 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Site'
+  /api/public-sites:
+    get:
+      summary: Get sites list
+      description: Returns a list of public sites
+      responses:
+        '200':
+          description: List of public sites
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sites:
+                    type: array
+                    description: List of sites
+                    items:
+                      $ref: '#/components/schemas/Site'
+        '500':
+          description: Server error
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Internal server error"
   /secure/get_groups:
     post:
       summary: Get distinct group identifiers
@@ -1253,6 +1277,127 @@ paths:
                 description: Error message from cryptographic operation
         '503':
           description: Database operation error
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "database error"
+  /api/secure-site:
+    put:
+      summary: Update an existing site
+      description: Updates an existing site with the provided information
+      security:
+        - sessionAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Site'
+      responses:
+        '200':
+          description: Site successfully updated
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "updated"
+        '400':
+          description: Bad request - invalid site data
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "bad request"
+        '401':
+          description: Unauthorized - User not logged in
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Unauthorized, please login"
+        '500':
+          description: Server error while updating site
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "database error"
+    post:
+      summary: Add a new site
+      description: Creates a new site with the provided information
+      security:
+        - sessionAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Site'
+      responses:
+        '201':
+          description: Site successfully created
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "created"
+        '400':
+          description: Bad request - invalid site data
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "bad request"
+        '401':
+          description: Unauthorized - User not logged in
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Unauthorized, please login"
+        '500':
+          description: Server error while creating site
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "database error"
+    delete:
+      summary: Delete a site
+      description: Removes an existing site from the system
+      security:
+        - sessionAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Site'
+      responses:
+        '200':
+          description: Site successfully deleted
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "deleted"
+        '400':
+          description: Bad request - invalid site data
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "bad request"
+        '401':
+          description: Unauthorized - User not logged in
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Unauthorized, please login"
+        '500':
+          description: Server error while deleting site
           content:
             text/plain:
               schema:

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -897,20 +897,6 @@ paths:
               schema:
                 type: string
                 example: "database error"
-  /api/old-sites:
-    get:
-      summary: Get all sites
-      description: Returns a list of all available sites with their location and status information
-      operationId: getSitesOld
-      responses:
-        '200':
-          description: List of sites
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Site'
   /api/sites:
     get:
       summary: Get all sites

--- a/openapi/v1/ccn-coverage-api.yaml
+++ b/openapi/v1/ccn-coverage-api.yaml
@@ -288,7 +288,7 @@ components:
           type: string
           description: Optional color identifier for the site in hex code 
           example: "#FF5733"
-        boundary:
+        boundary_array:
           type: array
           description: Optional geographical boundary coordinates defining the site perimeter as [latitude, longitude] pairs
           items:
@@ -341,7 +341,7 @@ components:
           type: string
           description: Optional color identifier for the site in hex code 
           example: "#FF5733"
-        boundary:
+        boundary_array:
           type: array
           description: Optional geographical boundary coordinates defining the site perimeter as [latitude, longitude] pairs
           items:


### PR DESCRIPTION
The old version of the API used names to identify Sites, which isn't a particularly stable form of identification. So I added an additional field called "identity" and modified the endpoints to use that as the primary identifier of Sites instead of the "name" parameter. The user passes in all fields except for the identity, which is a UUID generated randomly by the backend.